### PR TITLE
Primitive Iso combinators + make the direction of Iso more natural

### DIFF
--- a/src/Data/Intertwine/Combinators.purs
+++ b/src/Data/Intertwine/Combinators.purs
@@ -1,0 +1,86 @@
+-- | Primitive combinators for Iso
+module Data.Intertwine.Combinators
+    ( isoFlip
+    , isoTraverse
+    , isoFrom
+    , isoWrap
+    , isoJust
+    ) where
+
+import Prelude
+
+import Data.Intertwine.Iso (Iso(..))
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Traversable (class Traversable, sequence)
+
+-- | Constructs a never-failing `Iso` out of given "apply" and "inverse" functions
+isoFrom :: forall a b. (a -> b) -> (b -> a) -> Iso a b
+isoFrom apply inverse = Iso { apply: Just <<< apply, inverse: Just <<< inverse }
+
+-- | Revereses the direction of an `Iso`
+isoFlip :: forall a b. Iso a b -> Iso b a
+isoFlip (Iso i) = Iso { apply: i.inverse, inverse: i.apply }
+
+-- | Given a `Traversable` and an `Iso` that maps some values `a` and `b`,
+-- | produces a new `Iso` that maps those values wrapped in the `Traversable` -
+-- | `f a` and `f b`. This is handy for working for `Maybe`, for example:
+-- |
+-- |     -- First, define a never-failing Iso that maps a number
+-- |     -- to a number 5 greater than it
+-- |     plus5 :: Iso Int Int
+-- |     plus5 = isoFrom (_ + 5) (_ - 5)
+-- |
+-- |     > plus5.apply 37 == Just 42
+-- |     > plus5.inverse 42 == Just 37
+-- |
+-- |     -- Now, wrap it in a `Maybe`
+-- |     mPlus5 :: Iso (Maybe Int) (Maybe Int)
+-- |     mPlus5 = isoTraverse plus5
+-- |
+-- |     > mPlus5.apply (Just 37) == Just (Just 42)
+-- |     > mPlus5.inverse (Just 42) == Just (Just 37)
+-- |     > mPlus5.apply Nothing == Just Nothing
+-- |     > mPlus5.inverse Nothing == Just Nothing
+-- |
+-- |     -- Or wrap it in an `Array`
+-- |     aPlus5 :: Iso (Array Int) (Array Int)
+-- |     aPlus5 = isoTraverse plus5
+-- |
+-- |     > aPlus5.apply [37, 0] == Just [42, 5]
+-- |     > aPlus5.inverse [42, 5] == Just [37, 0]
+-- |     > aPlus5.apply [] == Just []
+-- |     > aPlus5.inverse [] == Just []
+-- |
+isoTraverse :: forall f a b. Traversable f => Iso a b -> Iso (f a) (f b)
+isoTraverse (Iso i) = Iso { apply: sequence <<< map i.apply, inverse: sequence <<< map i.inverse }
+
+-- | Constructs a never-failing `Iso` mapping a `newtype` to the type it wraps.
+-- | The intended use is to provide the `newtype`'s constructor as first
+-- | argument for the purpose of type inference.
+-- |
+-- | Example:
+-- |
+-- |     newtype N = N Int
+-- |     derive instance newtypeN :: Newtype N _
+-- |
+-- |     isoN :: Iso N N
+-- |     isoN = isoWrap N
+-- |
+-- |     > isoN.apply (N 42) == Just 42
+-- |     > isoN.inverse 42 == Just (N 42)
+-- |
+isoWrap :: forall w a. Newtype w a => (a -> w) -> Iso w a
+isoWrap _ = isoFrom unwrap wrap
+
+-- | An `Iso` that wraps any value in a `Just`, and unwraps on inverse, failing
+-- | when given `Nothing`.
+-- |
+-- | Example:
+-- |
+-- |     > isoJust.apply 42 == Just (Just 42)
+-- |     > isoJust.inverse (Just 42) = Just 42
+-- |     > isoJust.inverse Nothing = Nothing
+-- |
+isoJust :: forall a. Iso a (Maybe a)
+isoJust = Iso { apply: Just <<< Just, inverse: identity }

--- a/src/Data/Intertwine/Route.purs
+++ b/src/Data/Intertwine/Route.purs
@@ -11,11 +11,9 @@ module Data.Intertwine.Route
     , seg
     , segValue'
     , segValue
-    , newtypeSeg
     , constValue
     , query'
     , query
-    , newtypeQuery
 
     , module SyntaxReexport
     , module Data.Intertwine.Route.PathPiece
@@ -31,7 +29,6 @@ import Data.Intertwine.Syntax (Ctor(..), (<|$|>), (<|:|>), (<|*|>), (*|>), (<|||
 import Data.Intertwine.Syntax (class Syntax, atom, parse, print)
 import Data.Lens (Lens', lens, (^.), (%~), (.~))
 import Data.Maybe (Maybe(..))
-import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as Obj
 
@@ -107,17 +104,6 @@ constValue theValue = mkAtom prnt pars
 segValue :: forall a route. IsRoute route => PathPiece a => RoutesDef route a
 segValue = segValue' toPathSegment fromPathSegment
 
--- | A value of the given type as URL segment. This function is similar to
--- | `segValue`, but it uses an extra wrapping type that has an instance of
--- | `Newtype` and an instance of `PathPiece`. This is handy for defining
--- | `PathPiece` logic for types you don't control. The first parameter is not
--- | used, it's only present for type inference.
-newtypeSeg :: forall w a route. Newtype w a => IsRoute route => PathPiece w
-    => (a -> w) -> RoutesDef route a
-newtypeSeg _ = segValue'
-    ((wrap :: a -> w) >>> toPathSegment)
-    (map (unwrap :: w -> a) <<< fromPathSegment)
-
 -- | A value of the given type as URL segment. During printing, the printer
 -- | outputs the value as a URL segment, using the provided printing function to
 -- | convert it to a string. During parsing, the parser consumes a URL segment
@@ -141,18 +127,6 @@ segValue' printA parseA = mkAtom prnt pars
 -- | QueryString.
 query :: forall a route. IsRoute route => PathPiece a => String -> RoutesDef route (Maybe a)
 query key = query' toPathSegment fromPathSegment key
-
--- | QueryString value. This function is similar to `query`, but it uses an
--- | extra wrapping type that has an instance of `Newtype` and an instance of
--- | `PathPiece`. This is handy for defining `PathPiece` logic for types you
--- | don't control. The first parameter is not used, it's only present for type
--- | inference.
-newtypeQuery :: forall a w route. Newtype w a => IsRoute route => PathPiece w
-    => (a -> w) -> String -> RoutesDef route (Maybe a)
-newtypeQuery _ key = query'
-    ((wrap :: a -> w) >>> toPathSegment)
-    (map (unwrap :: w -> a) <<< fromPathSegment)
-    key
 
 -- | QueryString value. During printing adds the printed value (converted via
 -- | the given printing function) to the QueryString under given key. During

--- a/test/Combinators.purs
+++ b/test/Combinators.purs
@@ -3,7 +3,7 @@ module Test.Combinators where
 import Prelude
 
 import Data.Either (Either(..))
-import Data.Intertwine.Combinators (isoFlip, isoFrom, isoJust, isoTraverse, isoWrap)
+import Data.Intertwine.Combinators (isoFlip, isoFrom, isoJust, isoTraverse, isoUnwrap, isoWrap)
 import Data.Intertwine.Iso (Iso(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
@@ -27,8 +27,12 @@ allTests = describe "Combinators" do
             shouldEqual (inv (isoFlip plus5) 42) (Just 47)
     describe "isoWrap" do
         it "wraps newtype constructor" do
-            shouldEqual (ap (isoWrap N) (N 42)) (Just 42)
-            shouldEqual (inv (isoWrap N) 42) (Just (N 42))
+            shouldEqual (ap (isoWrap N) 42) (Just (N 42))
+            shouldEqual (inv (isoWrap N) (N 42)) (Just 42)
+    describe "isoUnrap" do
+        it "unwraps newtype constructor" do
+            shouldEqual (ap (isoUnwrap N) (N 42)) (Just 42)
+            shouldEqual (inv (isoUnwrap N) 42) (Just (N 42))
     describe "isoJust" do
         it "wraps in Just" do
             shouldEqual (ap isoJust 42) (Just (Just 42))

--- a/test/Combinators.purs
+++ b/test/Combinators.purs
@@ -1,0 +1,56 @@
+module Test.Combinators where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Intertwine.Combinators (isoFlip, isoFrom, isoJust, isoTraverse, isoWrap)
+import Data.Intertwine.Iso (Iso(..))
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+allTests :: Spec Unit
+allTests = describe "Combinators" do
+    describe "isoTraverse" do
+        it "traverses Array" do
+            shouldEqual (ap arrPlus5 [0, 1, 42]) (Just [5, 6, 47])
+            shouldEqual (inv arrPlus5 [5, 6, 47]) (Just [0, 1, 42])
+        it "traverses Either" do
+            shouldEqual (ap eitherPlus5 $ Right 42) (Just $ Right 47)
+            shouldEqual (ap eitherPlus5 $ Left "foo") (Just $ Left "foo")
+            shouldEqual (inv eitherPlus5 $ Right 42) (Just $ Right 37)
+            shouldEqual (inv eitherPlus5 $ Left "foo") (Just $ Left "foo")
+    describe "isoFlip" do
+        it "inverses direction" do
+            shouldEqual (ap (isoFlip plus5) 42) (Just 37)
+            shouldEqual (inv (isoFlip plus5) 42) (Just 47)
+    describe "isoWrap" do
+        it "wraps newtype constructor" do
+            shouldEqual (ap (isoWrap N) (N 42)) (Just 42)
+            shouldEqual (inv (isoWrap N) 42) (Just (N 42))
+    describe "isoJust" do
+        it "wraps in Just" do
+            shouldEqual (ap isoJust 42) (Just (Just 42))
+            shouldEqual (inv isoJust (Just 42)) (Just 42)
+            shouldEqual (inv isoJust Nothing) (Nothing :: Maybe Int)
+    where
+        ap :: forall a b. Iso a b -> a -> Maybe b
+        ap (Iso i) = i.apply
+
+        inv :: forall a b. Iso a b -> b -> Maybe a
+        inv (Iso i) = i.inverse
+
+newtype N a = N a
+derive instance newtypeN :: Newtype (N a) _
+derive newtype instance showN :: Show a => Show (N a)
+derive newtype instance eqN :: Eq a => Eq (N a)
+
+plus5 :: Iso Int Int
+plus5 = isoFrom (_ + 5) (_ - 5)
+
+arrPlus5 :: Iso (Array Int) (Array Int)
+arrPlus5 = isoTraverse plus5
+
+eitherPlus5 :: Iso (Either String Int) (Either String Int)
+eitherPlus5 = isoTraverse plus5

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
+import Test.Combinators as Combinators
 import Test.Route as Route
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (run)
@@ -12,3 +13,4 @@ main :: Effect Unit
 main = run [consoleReporter] do
     Text.allTests
     Route.allTests
+    Combinators.allTests

--- a/test/Route.purs
+++ b/test/Route.purs
@@ -6,7 +6,8 @@ import Control.Alt ((<|>))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Int as Int
-import Data.Intertwine.Route (class PathPiece, Ctor(..), PathInfo(..), RoutesDef, constValue, end, newtypeQuery, newtypeSeg, parseRoute, printRoute, query, query', seg, segValue, segValue', (*|>), (<|*|>), (<|:|>), (<|||>))
+import Data.Intertwine.Combinators (isoFlip, isoTraverse, isoWrap)
+import Data.Intertwine.Route (class PathPiece, Ctor(..), PathInfo(..), RoutesDef, constValue, end, parseRoute, printRoute, query, query', seg, segValue, segValue', (*|>), (<|$|>), (<|*|>), (<|:|>), (<|||>))
 import Data.Intertwine.Syntax ((<|*))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap, wrap)
@@ -80,9 +81,11 @@ route :: RoutesDef PathInfo Route
 route =
           (Ctor::Ctor "StandardRoute") <|:|> standardRoute <|* end
     <|||> (Ctor::Ctor "CT_Seg") <|:|> seg "ct_seg" *|> segValue' printCustomType parsCustomType <|* end
-    <|||> (Ctor::Ctor "CT_NewtypeSeg") <|:|> seg "ct_ntseg" *|> newtypeSeg Wrapper <|* end
+    <|||> (Ctor::Ctor "CT_NewtypeSeg") <|:|> seg "ct_ntseg" *|> (asCustomType <|$|> segValue) <|* end
     <|||> (Ctor::Ctor "CT_Query") <|:|> seg "ct_q" *|> query' printCustomType parsCustomType "q" <|* end
-    <|||> (Ctor::Ctor "CT_NewtypeQuery") <|:|> seg "ct_ntq" *|> newtypeQuery Wrapper "q" <|* end
+    <|||> (Ctor::Ctor "CT_NewtypeQuery") <|:|> seg "ct_ntq" *|> (isoTraverse asCustomType <|$|> query "q") <|* end
+    where
+        asCustomType = isoFlip $ isoWrap Wrapper
 
 standardRoute :: RoutesDef PathInfo StandardRoute
 standardRoute =

--- a/test/Route.purs
+++ b/test/Route.purs
@@ -6,7 +6,7 @@ import Control.Alt ((<|>))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Int as Int
-import Data.Intertwine.Combinators (isoFlip, isoTraverse, isoWrap)
+import Data.Intertwine.Combinators (isoTraverse, isoUnwrap)
 import Data.Intertwine.Route (class PathPiece, Ctor(..), PathInfo(..), RoutesDef, constValue, end, parseRoute, printRoute, query, query', seg, segValue, segValue', (*|>), (<|$|>), (<|*|>), (<|:|>), (<|||>))
 import Data.Intertwine.Syntax ((<|*))
 import Data.Maybe (Maybe(..))
@@ -85,7 +85,7 @@ route =
     <|||> (Ctor::Ctor "CT_Query") <|:|> seg "ct_q" *|> query' printCustomType parsCustomType "q" <|* end
     <|||> (Ctor::Ctor "CT_NewtypeQuery") <|:|> seg "ct_ntq" *|> (isoTraverse asCustomType <|$|> query "q") <|* end
     where
-        asCustomType = isoFlip $ isoWrap Wrapper
+        asCustomType = isoUnwrap Wrapper
 
 standardRoute :: RoutesDef PathInfo StandardRoute
 standardRoute =


### PR DESCRIPTION
The original purpose of this PR was to introduce the primitive `Iso` combinators - in the `.Combinators` module, and removing `newtypeSeg` and `newtypeQuery`, which can now be achieved via applying `isoWrap` and `isoUnwrap`.

But while doing that, I have realized that `Syntax::synApply` is declared backwards: if one considers `Iso a b` to be roughly analogous to a function `a -> b`, then `synApply`'s signature looked like `(a -> b) -> b -> a` rather than more natural `(a -> b) -> a -> b` (which is the signature of `$`).

So I have reversed the signature of `synApply`, and fixed up ripple effects from there - in `Syntax.purs` and `MkIso.purs`. 